### PR TITLE
Fixed 2 bugs

### DIFF
--- a/aic/util/padding.py
+++ b/aic/util/padding.py
@@ -11,11 +11,11 @@ class Padding:
                                 Top; Right; Bottom; Left - mimics the common CSS pattern
     """
 
-    def __init__(self, widths: tuple = (0, 0, 0, 0)):
-        self.padding = make_padding(widths)
+    def __init__(self, widths=tuple( (0, 0, 0, 0) )):
+        Self.padding = make_padding(widths)
 
 
-def make_padding(widths: tuple = (0, 0, 0, 0)):
+def make_padding(widths=tuple( (0, 0, 0, 0) )):
     """ returns a tuple of 4 integers representing the amount of padding-> Top; Right; Bottom; Left """
     length = len(widths)
     if length < 5:

--- a/simpleslider_example.py
+++ b/simpleslider_example.py
@@ -11,8 +11,8 @@ RESOURCES = 'res'
 
 
 class ICPanel(ImageControlPanel):
-    def __init__(self, parent, bmp, *args, tiled=False, **kwargs):
-        super().__init__(parent, bmp, *args, tiled, **kwargs)
+    def __init__(self, parent, bmp, tiled=False, *args, **kwargs):
+        super().__init__(parent, bmp, tiled, *args, **kwargs)
 
         self._populate()
 


### PR DESCRIPTION
Fixed 2 coding issues. 

Beyond this I am adding additional changes to allow this to also work in Python2 (not just Python3).
I will commit those separately, if you will like you can add those as well.  

Never the less I highly recommend accepting these changes as the python wouldn't even have of ran. It had bad syntax that I corrected.

  -----------------------------------------------------------------------------------------------------------------

  Fixed python syntax, bad syntax in function definitions/declarations in "simpleslider_example.py"

  This wouldn't even run.  You can't specify a named argument in a
  function declaration after "*args" but someone tried to.  I fixed this.
  They had: "*args, tiled=False, **kwargs
  Changed to: tiled=False, *args, **kwargs

  -----------------------------------------------------------------------------------------------------------------

  Improper casting into tupple  Python syntax does not permit variables in "aic/util/padding.py"

  (other than in a dictionary environment) to be set with a colon.
  User had: " width : tuple(0, 0, 0, 0)"
  Changed to: " width=tuple( (0, 0, 0, 0) )
  
  It would not even run as it was before.  Now it will.
  -----------------------------------------------------------------------------------------------------------------